### PR TITLE
Add support for Twitter Card and Opengraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ footnoteReturnLinkContents = "^"
   darkmode = true # set true if you prefer dark mode
 ```
 
+### Social media
+
+If you want to enable the generation of Twitter Card or Opengraph `meta` tags so you get nice embeds on Twitter, Facebook and other social media sites, add the following:
+
+```toml
+[Params]
+  twittercard = true
+  opengraph = true
+```
+
+See the [Internal Templates](https://gohugo.io/templates/internal/) in Hugo for how to configure this behaviour further.
+
 ## Shortcodes
 
 ### Sidenotes

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -12,6 +12,12 @@
 {{- end }}
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+{{ if site.Params.twittercard }}
+{{ template "_internal/twitter_cards.html" . }}
+{{- end }}
+{{ if site.Params.opengraph }}
+{{ template "_internal/opengraph.html" . }}
+{{- end }}
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/latex.css" />
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
 {{ if site.Params.darkmode }}


### PR DESCRIPTION
This includes two booleans to enable the generation of Twitter Card and Opengraph meta tags for better embeds on social media sites. The templates used are built into Hugo.