### PR TITLE
Add feed syndication

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,6 +18,9 @@
 {{ if site.Params.opengraph }}
 {{ template "_internal/opengraph.html" . }}
 {{- end }}
+{{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/latex.css" />
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
 {{ if site.Params.darkmode }}


### PR DESCRIPTION
This adds the alternative outputs as tags in the `<head>`, enabling the inclusion of RSS, ATOM and other types of output types.

For example, with:
```toml
[outputs]
    home = ["HTML", "RSS"]
```

This will now result in outputting a `<link rel="alternate" type="application/rss+xml" href="...index.xml" title="..."/>`

It's implemented as described on: https://gohugo.io/templates/rss/.