### PR TITLE
fix tags when baseURL = "/"

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
       {{ if .Params.tags }}
         <div class="blog-tags">
           {{ range .Params.tags }}
-            <a href="{{ $.Site.BaseURL }}/tags/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+          <a href="{{ (urlize (printf "tags/%s/" .)) | absLangURL }}">{{ . }}</a>&nbsp;
           {{ end }}
         </div>
       {{ end }}


### PR DESCRIPTION
This PR resolves #16

I've seen this trick used in other themes, such as [Terminal](https://github.com/panr/hugo-theme-terminal), and it's worked well for me. Just tested on my own site, deployed to two different domains, with baseURL = "/", and it works great.