### PR TITLE
Compatibility with last hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ example
 ```toml
 baseURL = "https://hugotex.vercel.app/"
 title = "HugoTeX"
-paginate = 3
 languageCode = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
 footnoteReturnLinkContents = "^"
+
+[pagination]
+  pagerSize = 3
 
 [Params.Author]
   name = "Kaito Sugimoto"

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,10 +1,12 @@
 baseURL = "https://hugotex.vercel.app/"
 title = "HugoTeX"
-paginate = 3
 languageCode = "en"
 DefaultContentLanguage = "en"
 enableInlineShortcodes = true
 footnoteReturnLinkContents = "^"
+
+[pagination]
+  pagerSize = 3
 
 [Params.author]
   name = "Kaito Sugimoto"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,7 +14,7 @@
         <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>,
         {{ end }}
         &copy;
-        {{ .Site.LastChange.Format "2006" }}
+        {{ .Site.Lastmod.Format "2006" }}
         <a href="{{ .Site.BaseURL }}about/">{{ .Site.Params.Author.name }}</a>
       </p>
   </div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.110.0"
+      "HUGO_VERSION": "0.134.0"
     }
   }
 }


### PR DESCRIPTION
Avoid warning:
```
WARN  deprecated: .Site.LastChange was deprecated in Hugo v0.123.0 and will be removed in a future release. Use .Site.Lastmod instead.
```
and
```
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
```
and update used hugo for CI to the last version.