### PR TITLE
Followup

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,5 +25,4 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/latex.css" />
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
 <script id="MathJax-script" async src="{{ .Site.BaseURL }}js/tex-mml-chtml.js"></script>
-{{ hugo.Generator }}
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,4 @@
+<head>
 <meta charset="utf-8" />
 {{ if .Title }}
   <title>{{ .Title }} - {{ .Site.Title }}</title>
@@ -24,4 +25,5 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/latex.css" />
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
 <script id="MathJax-script" async src="{{ .Site.BaseURL }}js/tex-mml-chtml.js"></script>
-{{ hugo.Generator -}}
+{{ hugo.Generator }}
+</head>


### PR DESCRIPTION
Here small followup:
1. Add missed `<head>` tag
2. Hugo manages to inject meta tags with version by its own and it is controled via `disableHugoGeneratorInject`. But to make it works as designed the theme shouldn't have explicit call of `hugo.Generator`.