### PR TITLE
Fix CSS loading by using relURL instead of BaseURL

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,12 +15,12 @@
     <ul class="pager">
       {{ if .Paginator.HasPrev }}
         <li class="previous">
-          <a href="{{ .Permalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; Newer</a>
+          <a href="{{ .RelPermalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; Newer</a>
         </li>
       {{ end }}
       {{ if .Paginator.HasNext }}
         <li class="next">
-          <a href="{{ .Permalink }}page/{{ .Paginator.Next.PageNumber }}/">Older &rarr;</a>
+          <a href="{{ .RelPermalink }}page/{{ .Paginator.Next.PageNumber }}/">Older &rarr;</a>
         </li>
       {{ end }}
     </ul>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
       {{ if .Params.tags }}
         <div class="blog-tags">
           {{ range .Params.tags }}
-          <a href="{{ (urlize (printf "tags/%s/" .)) | absLangURL }}">{{ . }}</a>&nbsp;
+          <a href="{{ printf "/tags/%s/" (. | urlize) | relURL }}">{{ . }}</a>&nbsp;
           {{ end }}
         </div>
       {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -5,7 +5,7 @@
     {{ range .Data.Terms.Alphabetical }}
       <div class="terms">
         <h4 class="term-name" >
-          <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>
+          <a href="{{ .Page.RelPermalink }}">{{ .Page.Title }}</a>
           <span class="badge">{{ .Count }}</span>
         </h4>
       </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     <p class="credits copyright">
       <p class="credits theme-by">
         {{ if .Site.Params.Legal }}
-        <a href="{{ .Site.BaseURL }}legal/">{{ .Site.Params.Legal }}</a>
+        <a href="{{ "legal/" | relURL }}">{{ .Site.Params.Legal }}</a>
         <br>
         {{ end }}
         {{ if .Site.Params.PoweredBy }}
@@ -11,11 +11,11 @@
         <br>
         {{ end }}
         {{ if .Site.Title }}
-        <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>,
+        <a href="{{ "/" | relURL }}">{{ .Site.Title }}</a>,
         {{ end }}
         &copy;
         {{ .Site.Lastmod.Format "2006" }}
-        <a href="{{ .Site.BaseURL }}about/">{{ .Site.Params.Author.name }}</a>
+        <a href="{{ "about/" | relURL }}">{{ .Site.Params.Author.name }}</a>
       </p>
   </div>
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,9 +22,9 @@
 {{ range .AlternativeOutputFormats -}}
     {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
 {{ end -}}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}css/latex.css" />
-<link rel="stylesheet" href="{{ .Site.BaseURL }}css/main.css" />
+<link rel="stylesheet" href="{{ "css/latex.css" | relURL }}" />
+<link rel="stylesheet" href="{{ "css/main.css" | relURL }}" />
 {{ if .Page.Store.Get "hasMath" }}
-<link rel="stylesheet" href="{{ .Site.BaseURL }}css/katex.min.css" />
+<link rel="stylesheet" href="{{ "css/katex.min.css" | relURL }}" />
 {{ end }}
 </head>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,8 +1,8 @@
 <nav class="navbar">
   <div class="nav">
     {{ if .Site.Params.logo }}
-      <a href="{{ .Site.BaseURL }}" class="nav-logo">
-      <img src="{{ .Site.BaseURL }}images/{{ .Site.Params.logo.url }}"
+      <a href="{{ "/" | relURL }}" class="nav-logo">
+      <img src="{{ printf "images/%s" .Site.Params.logo.url | relURL }}"
            width="{{ .Site.Params.logo.width }}"
            height="{{ .Site.Params.logo.height }}"
            alt="{{ .Site.Params.logo.alt }}">

--- a/layouts/partials/postmeta.html
+++ b/layouts/partials/postmeta.html
@@ -9,7 +9,7 @@
   {{ if .Params.categories }}
     <br><i class="fa fa-folder-open"></i>
     {{ range .Params.categories }}
-      <a href="{{ $.Site.BaseURL }}/categories/{{ . | urlize }}/">{{ . }}</a>&nbsp;
+      <a href="{{ printf "/categories/%s/" (. | urlize) | relURL }}">{{ . }}</a>&nbsp;
     {{ end }}
   {{ end }}
 </span>

--- a/layouts/partials/preview.html
+++ b/layouts/partials/preview.html
@@ -1,5 +1,5 @@
 <article class="post-preview">
-  <a href="{{ .Permalink }}">
+  <a href="{{ .RelPermalink }}">
       <h2 class="post-title">{{ .Title }}</h2>
   </a>
   <div class="postmeta">
@@ -8,7 +8,7 @@
   <div class="post-entry">
     {{ if .Truncated }}
       <p>{{ .Summary }}</p>
-        <a href="{{ .Permalink }}" class="post-read-more">Read More</a>
+        <a href="{{ .RelPermalink }}" class="post-read-more">Read More</a>
     {{ end }}
   </div>
 </article>


### PR DESCRIPTION
## Problem
CSS files (including katex.min.css), navigation links, category links, footer links, **pagination links, and post links** were not working correctly in Vercel preview deployments. The issue was that absolute URLs (`{{ .Site.BaseURL }}`, `{{ .Permalink }}`, `absLangURL`) were pointing to the production URL (`https://hugotex.vercel.app/`), causing 404 errors and broken navigation in preview deployments.

## Solution
Changed all asset and internal link references to use Hugo's relative URL functions (`relURL` and `RelPermalink`). This ensures all resources and links work correctly in both production and preview deployments.

## Changes
**CSS files (layouts/partials/head.html)**:
- `css/latex.css`: Now uses relURL
- `css/main.css`: Now uses relURL  
- `css/katex.min.css`: Now uses relURL

**Navigation (layouts/partials/nav.html)**:
- Home link: Now uses relURL
- Logo image: Now uses relURL

**Post metadata (layouts/partials/postmeta.html)**:
- Category links: Now uses relURL

**Footer (layouts/partials/footer.html)**:
- Legal page link: Now uses relURL
- Home link: Now uses relURL
- About page link: Now uses relURL

**Pagination (layouts/_default/list.html)**:
- Previous page link: Now uses RelPermalink
- Next page link: Now uses RelPermalink

**Post previews (layouts/partials/preview.html)**:
- Post title links: Now uses RelPermalink
- "Read More" links: Now uses RelPermalink

**Post details (layouts/_default/single.html)**:
- Tag links: Now uses relURL

**Term listings (layouts/_default/terms.html)**:
- Term links: Now uses RelPermalink

This follows Hugo best practices for asset loading and internal linking, ensuring proper functionality across different deployment environments.