### PR TITLE
Treat article's `.Summary` as Abstract

### DIFF
--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -20,17 +20,37 @@
           <h1>{{ if .Data.Singular }}#{{ end }}{{ .Title }}</h1>
         {{ else }}
           <h1>{{ with $title }}{{.}}{{ else }}<br/>{{ end }}</h1>
+          {{ $author := "" }}
+          {{ $abstract := "" }}
           {{ if .IsHome }}
-            <p class="author">{{ with .Site.Params.Author.name }}{{.}}{{ else }}<br/>{{ end }}</p>
-
-            {{ if .Site.Params.Author.abstract }}
-              <div class="abstract">
-                <h5>Abstract</h5>
-                <p>
-                  {{ .Site.Params.Author.abstract }}
-                </p>
-              </div>
-            {{ end }}
+            {{ $author = .Site.Params.Author.name }}
+            {{ $abstract = .Site.Params.Author.abstract }}
+          {{ else if not .IsPage }}
+          {{ else }}
+            {{ $author = .Params.author | default .Site.Params.Author.name }}
+          {{ end }}
+          {{ with $author }}
+            <p class="author">
+              <a href="{{ "about/" | relURL }}">{{ . }}</a> at <a href="{{ "/" | relURL }}">{{ $.Site.Title }}</a>
+              {{- if $.IsPage -}}
+                <br>
+                {{- $lastmod := $.Lastmod.Format ($.Site.Params.dateformat | default "Jan 2, 2006") -}}
+                {{- $pubdate := $.PublishDate.Format ($.Site.Params.dateformat | default "Jan 2, 2006") -}}
+                {{ $pubdate }}{{ if ne $lastmod $pubdate }} ({{ $lastmod }}){{ end }}
+                {{- if $.Params.categories -}}
+                  <br>
+                  {{- range $.Params.categories -}}
+                    <a href="{{ printf "/categories/%s/" (. | urlize) | relURL }}">{{ . }}</a>&nbsp;
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            </p>
+          {{ end }}
+          {{ with $abstract }}
+            <div class="abstract">
+              <h2>Abstract</h2>
+              <p>{{ . }}</p>
+            </div>
           {{ end }}
         {{ end }}
       </div>

--- a/layouts/_partials/preview.html
+++ b/layouts/_partials/preview.html
@@ -6,7 +6,7 @@
     {{ partial "postmeta.html" . }}
   </div>
   <div class="post-entry">
-    {{ if .Truncated }}
+    {{ if in .RawContent "<!--more-->" }}
       <p>{{ .Summary }}</p>
         <a href="{{ .RelPermalink }}" class="post-read-more">Read More</a>
     {{ end }}

--- a/layouts/_partials/toc.html
+++ b/layouts/_partials/toc.html
@@ -1,6 +1,14 @@
+{{- $content := .Content -}}
+{{- if in .RawContent "<!--more-->" -}}
+  {{- $parts := split .RawContent "<!--more-->" -}}
+  {{- if gt (len $parts) 1 -}}
+    {{- $content = index $parts 1 | $.RenderString -}}
+  {{- end -}}
+{{- end -}}
+
 {{ if and (gt .WordCount 400) (.Param "toc") }}
     {{- /* 正規表現でh[1-6]を探す */ -}}
-    {{- $header := (findRE "<h2.*?>(?:.|\n)*?</h2>" .Content) -}}
+    {{- $header := (findRE "<h2.*?>(?:.|\n)*?</h2>" $content) -}}
     {{- /* 最初に出現するh[1-6]を取得 */ -}}
     {{- $firstH := index $header 0 -}}
 
@@ -8,11 +16,11 @@
         {{- /* ヘッダーの前にToCを結合した「新しいヘッダー」を作成 */ -}}
         {{- $newH := printf `%s%s` .TableOfContents $firstH -}}
         {{- /* 古いヘッダーを新しいヘッダーに置換して出力 */ -}}
-        {{- replace .Content $firstH $newH | safeHTML -}}
+        {{- replace $content $firstH $newH | safeHTML -}}
     {{- else -}}
         {{- /* そもそもヘッダーがない時は普通に出力 */ -}}
-        {{- .Content -}}
+        {{- $content | safeHTML -}}
     {{- end -}}
 {{ else }}
-    {{ .Content }}
+    {{ $content | safeHTML }}
 {{ end }}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,10 +1,13 @@
 {{ define "main" }}
   <div class="container" role="main">
     <article class="article" class="blog-post">
-      <div class="postmeta">
-        {{ partial "postmeta.html" . }}
-      </div>
-      <br>
+      {{ if in .RawContent "<!--more-->" }}
+        <div class="abstract">
+          <h2>Abstract</h2>
+          <div>{{ .Summary }}</div>
+        </div>
+      {{ end }}
+
       {{ partial "toc.html" . }}
 
       {{ if .Params.tags }}


### PR DESCRIPTION
Each article has a short version, let use it as abstract to mimic academical style much more.

Right now abstract exists only on index page, but it's logical to use everything before `<!--more-->` as abstract.

Here three examples how it looks:
1. A page with `<!--more-->` as abstract: https://kirill.korins.ky/articles/kunerths-algorithm-for-modular-square-roots-a-forgotten-method/
2. Index with abstract from `hugo.toml`: https://kirill.korins.ky/
3. A page without `<!--more-->`: https://kirill.korins.ky/about/