### PR TITLE
Replace `.Site.LanguageCode` by `.Site.Language.Locale` and favicons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HugoTeX
 
-[![Hugo](https://img.shields.io/badge/Hugo-%5E0.153.0-blue.svg)](https://gohugo.io/)
+[![Hugo](https://img.shields.io/badge/Hugo-%5E0.158.0-blue.svg)](https://gohugo.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Stars](https://img.shields.io/github/stars/kaisugi/HugoTeX?style=social)](https://github.com/kaisugi/HugoTeX/stargazers)
 
@@ -37,7 +37,7 @@ Transform your Hugo site into a beautifully typeset document with the classic ae
 
 ### Prerequisites
 
-- Hugo >= **0.153.0** ([Download Hugo](https://gohugo.io/installation/))
+- Hugo >= **0.158.0** ([Download Hugo](https://gohugo.io/installation/))
 - Git
 
 ### Try It Out

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ footnoteReturnLinkContents = "^"
 [Params]
   darkmode = true  # Set to true to enforce dark mode
   # lightmode = true  # Set to true to enforce light mode
+  [Params.Favicon]
+    ico = "/favicon.ico"
+    svg = "/favicon.svg"
+    png = "/favicon.png"
 
 [Params.Author]
   name = "Your Name"
@@ -147,6 +151,40 @@ By default, dark mode automatically activates based on the user's system `prefer
 - Set `darkmode = true` to enforce dark mode
 - Set `lightmode = true` to enforce light mode
 - Omit both for automatic switching
+
+### Favicon Support
+
+Define icon paths once under `[Params.Favicon]`. Every field is optional; only provided values are rendered.
+The recommended setup uses `/favicon.ico`, `/favicon.svg`, and `/favicon.png`.
+`ico` should point to a multi-size `.ico` file, at minimum 16, 32, and 48 px, for legacy browser support.
+`png` is rendered as both a 180x180 PNG favicon fallback and the Apple touch icon.
+
+```toml
+[Params.Favicon]
+  ico = "/favicon.ico"                     # Legacy multi-size .ico fallback
+  svg = "/favicon.svg"                     # SVG icon for modern browsers
+  png = "/favicon.png"                     # 180x180 PNG fallback and Apple touch icon
+```
+
+Place these files in the site's `static` directory:
+`static/favicon.ico`, `static/favicon.svg`, and `static/favicon.png`.
+For an SVG with shadows, filters, or transparent padding, render a large
+PNG first, trim the transparent canvas, then resize and re-center the
+result:
+
+```sh
+rsvg-convert -f png -w 2048 -h 2048 -o /tmp/favicon-2048.png static/favicon.svg
+
+convert /tmp/favicon-2048.png -alpha set -trim +repage -resize 180x180 -background none -gravity center -extent 180x180 static/favicon.png
+
+convert /tmp/favicon-2048.png -alpha set -trim +repage -resize 16x16 -background none -gravity center -extent 16x16 /tmp/favicon-16.png
+convert /tmp/favicon-2048.png -alpha set -trim +repage -resize 32x32 -background none -gravity center -extent 32x32 /tmp/favicon-32.png
+convert /tmp/favicon-2048.png -alpha set -trim +repage -resize 48x48 -background none -gravity center -extent 48x48 /tmp/favicon-48.png
+
+convert /tmp/favicon-16.png /tmp/favicon-32.png /tmp/favicon-48.png static/favicon.ico
+
+rm -f /tmp/favicon-2048.png /tmp/favicon-16.png /tmp/favicon-32.png /tmp/favicon-48.png
+```
 
 ### Social Media Integration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HugoTeX
 
-[![Hugo](https://img.shields.io/badge/Hugo-%5E0.146.0-blue.svg)](https://gohugo.io/)
+[![Hugo](https://img.shields.io/badge/Hugo-%5E0.153.0-blue.svg)](https://gohugo.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Stars](https://img.shields.io/github/stars/kaisugi/HugoTeX?style=social)](https://github.com/kaisugi/HugoTeX/stargazers)
 
@@ -37,7 +37,7 @@ Transform your Hugo site into a beautifully typeset document with the classic ae
 
 ### Prerequisites
 
-- Hugo >= **0.146.0** ([Download Hugo](https://gohugo.io/installation/))
+- Hugo >= **0.153.0** ([Download Hugo](https://gohugo.io/installation/))
 - Git
 
 ### Try It Out

--- a/exampleSite/content/post/rich-content.md
+++ b/exampleSite/content/post/rich-content.md
@@ -21,9 +21,9 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ---
 
-## Twitter Simple Shortcode
+## X Shortcode
 
-{{< twitter_simple user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 

--- a/layouts/_partials/favicons.html
+++ b/layouts/_partials/favicons.html
@@ -1,0 +1,14 @@
+{{- $favicon := site.Params.Favicon | default site.Params.favicon -}}
+{{- with $favicon }}
+  {{- with .ico }}
+<link rel="icon" type="image/vnd.microsoft.icon" sizes="16x16 32x32 48x48" href="{{ . | relURL }}">
+  {{- end }}
+  {{- with .png }}
+<meta name="apple-mobile-web-app-title" content="{{ site.Title }}">
+<link rel="icon" type="image/png" sizes="180x180" href="{{ . | relURL }}">
+<link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{{ . | relURL }}">
+  {{- end }}
+  {{- with .svg }}
+<link rel="icon" type="image/svg+xml" sizes="any" href="{{ . | relURL }}">
+  {{- end }}
+{{- end }}

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -1,5 +1,6 @@
 <head>
 <meta charset="utf-8" />
+{{ partial "favicons.html" . }}
 {{ if .Title }}
   <title>{{ .Title }} - {{ .Site.Title }}</title>
 {{ else }}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     {{- partial "head.html" . -}}
     {{- if site.Params.darkmode -}}
     <body class="latex-dark">

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/kaisugi/HugoTeX"
 demosite = "https://hugotex.vercel.app/"
 tags = ["dark", "light", "blog", "minimal", "simple", "LaTeX"]
 features = ["minimal", "simple", "responsive", "syntax highlight", "LaTeX"]
-min_version = "0.153.0"
+min_version = "0.158.0"
 
 [author]
   name = "kaisugi"

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/kaisugi/HugoTeX"
 demosite = "https://hugotex.vercel.app/"
 tags = ["dark", "light", "blog", "minimal", "simple", "LaTeX"]
 features = ["minimal", "simple", "responsive", "syntax highlight", "LaTeX"]
-min_version = "0.146.0"
+min_version = "0.153.0"
 
 [author]
   name = "kaisugi"

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.153.0"
+      "HUGO_VERSION": "0.158.0"
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.146.0"
+      "HUGO_VERSION": "0.153.0"
     }
   }
 }


### PR DESCRIPTION
It was depricated in v0.158.0 and replacment introduced in 0.153.0.

And as the second commit here optional support of favicons.