### PR TITLE
Cleanup usage of <p> and <a> tags

### DIFF
--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -1,21 +1,20 @@
 <footer>
   <div class="container">
-    <p class="credits copyright">
-      <p class="credits theme-by">
-        {{ if .Site.Params.Legal }}
-        <a href="{{ "legal/" | relURL }}">{{ .Site.Params.Legal }}</a>
-        <br>
-        {{ end }}
-        {{ if .Site.Params.PoweredBy }}
-        Powered By <a href="https://gohugo.io">Hugo</a>&nbsp;/&nbsp;Theme&nbsp;<a href="https://github.com/kaisugi/HugoTeX">HugoTeX</a>
-        <br>
-        {{ end }}
-        {{ if .Site.Title }}
-        <a href="{{ "/" | relURL }}">{{ .Site.Title }}</a>,
-        {{ end }}
-        &copy;
-        {{ .Site.Lastmod.Format "2006" }}
-        <a href="{{ "about/" | relURL }}">{{ .Site.Params.Author.name }}</a>
-      </p>
+    <p class="credits theme-by">
+      {{ if .Site.Params.Legal }}
+      <a href="{{ "legal/" | relURL }}">{{ .Site.Params.Legal }}</a>
+      <br>
+      {{ end }}
+      {{ if .Site.Params.PoweredBy }}
+      Powered By <a href="https://gohugo.io">Hugo</a>&nbsp;/&nbsp;Theme&nbsp;<a href="https://github.com/kaisugi/HugoTeX">HugoTeX</a>
+      <br>
+      {{ end }}
+      {{ if .Site.Title }}
+      <a href="{{ "/" | relURL }}">{{ .Site.Title }}</a>,
+      {{ end }}
+      &copy;
+      {{ .Site.Lastmod.Format "2006" }}
+      <a href="{{ "about/" | relURL }}">{{ .Site.Params.Author.name }}</a>
+    </p>
   </div>
 </footer>

--- a/layouts/_partials/preview.html
+++ b/layouts/_partials/preview.html
@@ -1,14 +1,13 @@
 <article class="post-preview">
-  <a href="{{ .RelPermalink }}">
-      <h2 class="post-title">{{ .Title }}</h2>
-  </a>
+  <h2 class="post-title">
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  </h2>
   <div class="postmeta">
     {{ partial "postmeta.html" . }}
   </div>
   <div class="post-entry">
     {{ if in .RawContent "<!--more-->" }}
-      <p>{{ .Summary }}</p>
-        <a href="{{ .RelPermalink }}" class="post-read-more">Read More</a>
+      {{ .Summary }}
     {{ end }}
   </div>
 </article>


### PR DESCRIPTION
`.Summary` already contains it's own `<p>`, no need to wrap it into `<p>`

Also `<a>` tag should be inside `<h2>`, not a container for `<h2>`

And remove "Read more" to make google's pagespeed insigth happy.