### PR TITLE
Optional support dark and light code's highligh

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,24 @@ Change the code highlighting theme in your config:
   style = "monokai"  # Try: github, dracula, nord, etc.
 ```
 
+To use different code highlighting styles for light and dark modes,
+keep the light style in Hugo's standard markup configuration and set
+only the dark style under theme parameters:
+
+```toml
+[markup.highlight]
+  style = "tango"
+
+[Params.SyntaxHighlighting]
+  DarkStyle = "paraiso-dark"
+```
+
+`LightStyle` is optional; when omitted, HugoTeX uses
+`markup.highlight.style` as the light style. Forced light mode renders
+only the light style, forced dark mode renders only the dark style, and
+automatic mode renders both variants while CSS follows
+`prefers-color-scheme`.
+
 Browse available styles: [Chroma Style Gallery](https://xyproto.github.io/splash/docs/)
 
 ### Custom CSS

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -25,3 +25,25 @@ footer .theme-by {
   float: right;
   display: block;
 }
+
+.chroma-switch .highlight.chroma-dark {
+  display: none;
+}
+
+.latex-dark .chroma-switch .highlight.chroma-light {
+  display: none;
+}
+
+.latex-dark .chroma-switch .highlight.chroma-dark {
+  display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+  .latex-dark-auto .chroma-switch .highlight.chroma-light {
+    display: none;
+  }
+
+  .latex-dark-auto .chroma-switch .highlight.chroma-dark {
+    display: block;
+  }
+}

--- a/layouts/_markup/render-codeblock.html
+++ b/layouts/_markup/render-codeblock.html
@@ -1,0 +1,39 @@
+{{- $syntaxHighlighting := site.Params.SyntaxHighlighting | default site.Params.syntaxHighlighting | default dict -}}
+{{- $lightStyleParam := $syntaxHighlighting.LightStyle | default $syntaxHighlighting.lightStyle -}}
+{{- $darkStyle := $syntaxHighlighting.DarkStyle | default $syntaxHighlighting.darkStyle -}}
+{{- $enabled := or $lightStyleParam $darkStyle -}}
+{{- if not $enabled -}}
+  {{- $result := transform.HighlightCodeBlock . -}}
+  {{- $result.Wrapped -}}
+{{- else if site.Params.darkmode -}}
+  {{- $style := $darkStyle | default $lightStyleParam -}}
+  {{- if $style -}}
+    {{- $result := transform.HighlightCodeBlock . (merge .Options (dict "style" $style)) -}}
+    {{- $result.Wrapped -}}
+  {{- else -}}
+    {{- $result := transform.HighlightCodeBlock . -}}
+    {{- $result.Wrapped -}}
+  {{- end -}}
+{{- else if site.Params.lightmode -}}
+  {{- $lightOptions := .Options -}}
+  {{- if $lightStyleParam -}}
+    {{- $lightOptions = merge $lightOptions (dict "style" $lightStyleParam) -}}
+  {{- end -}}
+  {{- $result := transform.HighlightCodeBlock . $lightOptions -}}
+  {{- $result.Wrapped -}}
+{{- else if $darkStyle -}}
+  {{- $lightOptions := merge .Options (dict "wrapperClass" "highlight chroma-light") -}}
+  {{- if $lightStyleParam -}}
+    {{- $lightOptions = merge $lightOptions (dict "style" $lightStyleParam) -}}
+  {{- end -}}
+  {{- $darkOptions := merge .Options (dict "style" $darkStyle "wrapperClass" "highlight chroma-dark") -}}
+  {{- $lightResult := transform.HighlightCodeBlock . $lightOptions -}}
+  {{- $darkResult := transform.HighlightCodeBlock . $darkOptions -}}
+  <div class="chroma-switch">
+    {{- $lightResult.Wrapped -}}
+    {{- $darkResult.Wrapped -}}
+  </div>
+{{- else -}}
+  {{- $result := transform.HighlightCodeBlock . (merge .Options (dict "style" $lightStyleParam)) -}}
+  {{- $result.Wrapped -}}
+{{- end -}}


### PR DESCRIPTION
As usual, it already deployed at https://kirill.korins.ky/articles/hugo-site-publishing-with-respectful-caching-and-indexnow-submission/