### PR TITLE
Add Cloudflare Pages demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Transform your Hugo site into a beautifully typeset document with the classic ae
 
 ![screenshot](https://user-images.githubusercontent.com/36184621/154785719-a9ef69da-7672-4e13-bf0d-5565cf0c99e2.png)
 
+**[Live Demo →](https://hugotex.pages.dev/)**
+
 ## ✨ Features
 
 - 📐 **LaTeX-style Typography** - Classic, elegant document styling inspired by LaTeX

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://hugotex.pages.dev/"
 title = "HugoTeX"
 languageCode = "en"
 DefaultContentLanguage = "en"

--- a/theme.toml
+++ b/theme.toml
@@ -3,6 +3,7 @@ license = "MIT"
 licenselink = "https://github.com/hugotex-dev/HugoTeX/blob/main/LICENSE"
 description = "LaTeX style hugo theme"
 homepage = "https://github.com/hugotex-dev/HugoTeX"
+demosite = "https://hugotex.pages.dev/"
 tags = ["dark", "light", "blog", "minimal", "simple", "LaTeX"]
 features = ["minimal", "simple", "responsive", "syntax highlight", "LaTeX"]
 min_version = "0.158.0"


### PR DESCRIPTION
## Summary
- Set `exampleSite/hugo.toml` baseURL to the live deployment at `https://hugotex.pages.dev/`
- Restore the Live Demo link in `README.md`
- Restore `demosite` in `theme.toml`

Verified that the Cloudflare Pages build succeeds at https://hugotex.pages.dev/ after the prior cleanup that dropped Vercel.

## Test plan
- [x] Cloudflare Pages preview deployment for this PR builds successfully
- [x] Preview URL renders the example site with the new baseURL

🤖 Generated with [Claude Code](https://claude.com/claude-code)