### PR TITLE
Deploy demo via GitHub Actions to support fork PR previews

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,41 @@
+name: Production Deploy
+
+# Publishes the demo site to production (hugotex.pages.dev) on every push to
+# main. This replaces the previous Cloudflare native Git integration, which is
+# why production deploys now live in GitHub Actions too.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: 0.158.0
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Hugo (extended)
+        run: |
+          wget -q -O hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i hugo.deb
+
+      - name: Build exampleSite (production baseURL from hugo.toml)
+        run: |
+          hugo --source exampleSite --themesDir ../.. --theme HugoTeX \
+            --minify --destination "${GITHUB_WORKSPACE}/public"
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy public
+            --project-name=hugotex
+            --branch=main

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,46 @@
+name: Preview Build
+
+# Runs on every PR, including PRs from forks. This workflow has NO access to
+# secrets (permissions are read-only and no secrets are referenced), so it is
+# safe to run against untrusted fork code. It only builds the demo site and
+# uploads the result as an artifact, which the "Preview Deploy" workflow then
+# publishes from the trusted base-repo context.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  HUGO_VERSION: 0.158.0
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Hugo (extended)
+        run: |
+          wget -q -O hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i hugo.deb
+
+      - name: Build exampleSite (root-relative URLs for preview)
+        run: |
+          hugo --source exampleSite --themesDir ../.. --theme HugoTeX \
+            --minify --baseURL "/" \
+            --destination "${GITHUB_WORKSPACE}/public"
+
+      - name: Record PR number for the deploy workflow
+        run: echo "${{ github.event.number }}" > pr-number
+
+      - name: Upload site artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-site
+          path: |
+            public
+            pr-number
+          retention-days: 3

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,74 @@
+name: Preview Deploy
+
+# Triggered when "Preview Build" finishes. workflow_run always runs from the
+# default branch (main), so it executes trusted code while still having access
+# to the Cloudflare secrets needed to deploy. The fork's code is never run here;
+# we only download and publish the artifact it produced.
+on:
+  workflow_run:
+    workflows: ["Preview Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-site
+          path: artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat artifact/pr-number)" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy artifact/public
+            --project-name=hugotex
+            --branch=pr-${{ steps.pr.outputs.number }}
+
+      - name: Comment preview URL on the PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const url = '${{ steps.deploy.outputs.deployment-url }}';
+            const marker = '<!-- cf-pages-preview -->';
+            const body = `${marker}\n🚀 **Cloudflare Pages preview deployed**\n\n${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## Why

Cloudflare Pages' native Git integration does not create preview deployments for PRs from forks (a deliberate security restriction so fork code never receives build secrets). As a result, external contributors' PRs never got a preview URL — see the discussion in #43.

## What

Move deploys to GitHub Actions using the safe `pull_request` + `workflow_run` pattern:

- **`preview-build.yml`** — runs on every PR (including forks) with **no secrets** and `contents: read` only, so it is safe to execute untrusted fork code. Builds the demo (`exampleSite`) with `--baseURL "/"` (root-relative URLs resolve under any preview domain) and uploads the output as an artifact.
- **`preview-deploy.yml`** — triggered by `workflow_run`, so it always runs from the **trusted `main` context** with access to secrets, without ever executing fork code. Downloads the artifact, deploys to Cloudflare Pages under a per-PR branch (`pr-<n>`), and comments the preview URL on the PR.
- **`deploy-production.yml`** — publishes `hugotex.pages.dev` on push to `main`, replacing the Cloudflare Git integration.

## Required before merge

1. Repo secrets: `CLOUDFLARE_API_TOKEN` (Pages: Edit) and `CLOUDFLARE_ACCOUNT_ID`. ✅ added
2. Disconnect the Cloudflare Pages Git integration so the project becomes Direct Upload (do this right before merge to avoid a production deploy gap).

After merge, existing fork PRs (e.g. #43) will get a preview once rebased/re-pushed onto the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)